### PR TITLE
Added check for gatsby in devDependencies.

### DIFF
--- a/packages/gatsby-cli/src/index.js
+++ b/packages/gatsby-cli/src/index.js
@@ -11,7 +11,7 @@ let inGatsbySite = false
 let localPackageJSON
 try {
   localPackageJSON = require(path.resolve(`./package.json`))
-  if (localPackageJSON.dependencies && localPackageJSON.dependencies.gatsby) {
+  if (localPackageJSON.dependencies && localPackageJSON.dependencies.gatsby || localPackageJSON.devDependencies && localPackageJSON.devDependencies.gatsby) {
     inGatsbySite = true
   }
 } catch (e) {


### PR DESCRIPTION
Following from discussion in #832, this adds a check for Gatsby in the current project's devDependencies in addition to dependencies.